### PR TITLE
Fix: Prevent negative height in course display

### DIFF
--- a/app/(tabs)/scheduler.tsx
+++ b/app/(tabs)/scheduler.tsx
@@ -38,7 +38,10 @@ const TimetableScheduler = () => {
 
     const top = startTimeIndex * CELL_HEIGHT;
     const left = dayIndex * DAY_WIDTH;
-    const height = (endTimeIndex - startTimeIndex) * CELL_HEIGHT - 2; // -2 for margin
+    let height = (endTimeIndex - startTimeIndex) * CELL_HEIGHT - 2; // -2 for margin
+    if (height < 0) {
+        height = CELL_HEIGHT - 2;
+    }
     const width = DAY_WIDTH - 2; // -2 for margin
 
     return { top, left, height, width };


### PR DESCRIPTION
In the scheduler view, courses with the same start and end time would be rendered with a negative height, causing a visual glitch.

This commit fixes the issue by modifying the `getCoursePosition` function in `app/(tabs)/scheduler.tsx`. The function now checks if the calculated height is negative. If it is, the height is set to a default minimum value to ensure the course is still visible on the schedule.